### PR TITLE
Passing the separator after the array is no longer supported

### DIFF
--- a/src/Input/Types/Argument.php
+++ b/src/Input/Types/Argument.php
@@ -72,6 +72,6 @@ class Argument extends Input\AbstractInputType
             $second[$ii] = $secondaryLineLeadPadding.$second[$ii];
         }
 
-        return $first.implode($second, PHP_EOL);
+        return $first.implode(PHP_EOL, $second);
     }
 }

--- a/src/Input/Types/LongOption.php
+++ b/src/Input/Types/LongOption.php
@@ -84,6 +84,6 @@ class LongOption extends Input\AbstractInputType
             $second[$ii] = $secondaryLineLeadPadding.$second[$ii];
         }
 
-        return $first.implode($second, PHP_EOL);
+        return $first.implode(PHP_EOL, $second);
     }
 }


### PR DESCRIPTION
neccessary changes for php 8